### PR TITLE
Shared Firestore Access.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,14 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="delegatedBuild" value="true" />
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/lemon-pi-protos" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/src/main/kotlin/com/normtronix/meringue/SharedFirestoreAccess.kt
+++ b/src/main/kotlin/com/normtronix/meringue/SharedFirestoreAccess.kt
@@ -1,0 +1,139 @@
+package com.normtronix.meringue
+
+import com.google.cloud.firestore.DocumentSnapshot
+import com.google.cloud.firestore.Firestore
+import java.util.concurrent.TimeUnit
+
+/**
+ * Shared Firestore read-only access for pitcrew functionality.
+ *
+ * *** IMPORTANT: This file is shared between projects ***
+ * - lemon-pi-meringue (this project)
+ * - lemons-racer-dot-com
+ *
+ * When modifying this file, manually copy changes to the other project
+ * and update the package name accordingly.
+ *
+ * This class provides direct Firestore access for checking car status,
+ * allowing the web app to bypass gRPC calls when just polling for status.
+ */
+class SharedFirestoreAccess(private val db: Firestore) {
+
+    data class DeviceInfo(
+        val trackCode: String,
+        val carNumber: String,
+        val teamCode: String,
+        val emailAddresses: List<String>
+    )
+
+    data class CarStatus(
+        val isOnline: Boolean,
+        val ipAddress: String?,
+        val deviceId: String?
+    )
+
+    /**
+     * Find device IDs associated with an email address and team code.
+     * Used for authentication lookup.
+     */
+    fun findDevicesByEmailAndTeamCode(email: String, teamCode: String): List<String> {
+        return try {
+            val query = db.collection(DEVICE_IDS)
+                .whereArrayContains(EMAIL_ADDRESSES, email)
+                .get()
+                .get(10, TimeUnit.SECONDS)
+            query.documents
+                .filter { it.getString(TEAM_CODE) == teamCode }
+                .map { it.id }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
+     * Get device information by device ID.
+     */
+    fun getDeviceInfo(deviceId: String): DeviceInfo? {
+        return try {
+            val doc = db.collection(DEVICE_IDS).document(deviceId).get().get(10, TimeUnit.SECONDS)
+            if (doc.exists()) {
+                val track = doc.getString(TRACK_CODE) ?: return null
+                val car = doc.getString(CAR_NUMBER) ?: return null
+                val team = doc.getString(TEAM_CODE) ?: return null
+                val emails = (doc.get(EMAIL_ADDRESSES) as? List<*>)?.filterIsInstance<String>() ?: emptyList()
+                DeviceInfo(track, car, team, emails)
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Get the online status of a car.
+     * Cars are considered online if their TTL timestamp is within the last 10 minutes.
+     */
+    fun getCarStatus(trackCode: String, carNumber: String): CarStatus? {
+        return try {
+            val doc = db.collection(ONLINE_CARS).document("$trackCode:$carNumber").get().get(10, TimeUnit.SECONDS)
+            if (doc.contains(TTL) && doc.contains(IP)) {
+                CarStatus(
+                    isOnline = isRecentTTL(doc),
+                    ipAddress = doc.getString(IP),
+                    deviceId = doc.getString(DEVICE_ID)
+                )
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Convenience method to get car status for all devices associated with given device IDs.
+     * Returns a list of car statuses with their track/car info.
+     */
+    fun getCarStatusForDevices(deviceIds: List<String>): List<CarStatusWithInfo> {
+        return deviceIds.mapNotNull { deviceId ->
+            val info = getDeviceInfo(deviceId) ?: return@mapNotNull null
+            val status = getCarStatus(info.trackCode, info.carNumber)
+            CarStatusWithInfo(
+                carNumber = info.carNumber,
+                trackCode = info.trackCode,
+                isOnline = status?.isOnline ?: false,
+                ipAddress = status?.ipAddress
+            )
+        }
+    }
+
+    data class CarStatusWithInfo(
+        val carNumber: String,
+        val trackCode: String,
+        val isOnline: Boolean,
+        val ipAddress: String?
+    )
+
+    private fun isRecentTTL(doc: DocumentSnapshot): Boolean {
+        val ttl = doc.getTimestamp(TTL) ?: return false
+        return System.currentTimeMillis() / 1000 - ttl.seconds < TEN_MINUTES
+    }
+
+    companion object {
+        // DeviceIds collection
+        internal const val DEVICE_IDS = "DeviceIds"
+        internal const val TRACK_CODE = "trackCode"
+        internal const val CAR_NUMBER = "carNumber"
+        internal const val TEAM_CODE = "teamCode"
+        internal const val EMAIL_ADDRESSES = "emailAddresses"
+
+        // OnlineCars collection
+        internal const val ONLINE_CARS = "onlineCars"
+        internal const val IP = "ip"
+        internal const val DEVICE_ID = "dId"
+        internal const val TTL = "ttl"
+
+        internal const val TEN_MINUTES = 10 * 60
+    }
+}

--- a/src/test/kotlin/com/normtronix/meringue/SharedFirestoreAccessTest.kt
+++ b/src/test/kotlin/com/normtronix/meringue/SharedFirestoreAccessTest.kt
@@ -1,0 +1,139 @@
+package com.normtronix.meringue
+
+import com.google.api.core.ApiFutures
+import com.google.cloud.Timestamp
+import com.google.cloud.firestore.*
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SharedFirestoreAccessTest {
+
+    private lateinit var db: Firestore
+    private lateinit var sharedAccess: SharedFirestoreAccess
+
+    @BeforeEach
+    fun setup() {
+        db = mockk()
+        sharedAccess = SharedFirestoreAccess(db)
+    }
+
+    @Test
+    fun testGetDeviceInfo() {
+        val docRef = mockk<DocumentReference>()
+        val docSnapshot = mockk<DocumentSnapshot>()
+        val collection = mockk<CollectionReference>()
+
+        every { db.collection("DeviceIds") } returns collection
+        every { collection.document("device123") } returns docRef
+        every { docRef.get() } returns ApiFutures.immediateFuture(docSnapshot)
+        every { docSnapshot.exists() } returns true
+        every { docSnapshot.getString("trackCode") } returns "thil"
+        every { docSnapshot.getString("carNumber") } returns "181"
+        every { docSnapshot.getString("teamCode") } returns "team1"
+        every { docSnapshot.get("emailAddresses") } returns listOf("test@example.com")
+
+        val info = sharedAccess.getDeviceInfo("device123")
+
+        assertNotNull(info)
+        assertEquals("thil", info?.trackCode)
+        assertEquals("181", info?.carNumber)
+        assertEquals("team1", info?.teamCode)
+        assertEquals(listOf("test@example.com"), info?.emailAddresses)
+    }
+
+    @Test
+    fun testGetDeviceInfoNotFound() {
+        val docRef = mockk<DocumentReference>()
+        val docSnapshot = mockk<DocumentSnapshot>()
+        val collection = mockk<CollectionReference>()
+
+        every { db.collection("DeviceIds") } returns collection
+        every { collection.document("unknown") } returns docRef
+        every { docRef.get() } returns ApiFutures.immediateFuture(docSnapshot)
+        every { docSnapshot.exists() } returns false
+
+        val info = sharedAccess.getDeviceInfo("unknown")
+
+        assertNull(info)
+    }
+
+    @Test
+    fun testGetCarStatusOnline() {
+        val docRef = mockk<DocumentReference>()
+        val docSnapshot = mockk<DocumentSnapshot>()
+        val collection = mockk<CollectionReference>()
+
+        // Recent timestamp (within 10 minutes)
+        val recentTimestamp = Timestamp.ofTimeSecondsAndNanos(
+            System.currentTimeMillis() / 1000 - 60, 0
+        )
+
+        every { db.collection("onlineCars") } returns collection
+        every { collection.document("thil:181") } returns docRef
+        every { docRef.get() } returns ApiFutures.immediateFuture(docSnapshot)
+        every { docSnapshot.contains("ttl") } returns true
+        every { docSnapshot.contains("ip") } returns true
+        every { docSnapshot.getTimestamp("ttl") } returns recentTimestamp
+        every { docSnapshot.getString("ip") } returns "192.168.1.100"
+        every { docSnapshot.getString("dId") } returns "device123"
+
+        val status = sharedAccess.getCarStatus("thil", "181")
+
+        assertNotNull(status)
+        assertTrue(status!!.isOnline)
+        assertEquals("192.168.1.100", status.ipAddress)
+        assertEquals("device123", status.deviceId)
+    }
+
+    @Test
+    fun testGetCarStatusOffline() {
+        val docRef = mockk<DocumentReference>()
+        val docSnapshot = mockk<DocumentSnapshot>()
+        val collection = mockk<CollectionReference>()
+
+        // Old timestamp (more than 10 minutes ago)
+        val oldTimestamp = Timestamp.ofTimeSecondsAndNanos(
+            System.currentTimeMillis() / 1000 - 700, 0
+        )
+
+        every { db.collection("onlineCars") } returns collection
+        every { collection.document("thil:181") } returns docRef
+        every { docRef.get() } returns ApiFutures.immediateFuture(docSnapshot)
+        every { docSnapshot.contains("ttl") } returns true
+        every { docSnapshot.contains("ip") } returns true
+        every { docSnapshot.getTimestamp("ttl") } returns oldTimestamp
+        every { docSnapshot.getString("ip") } returns "192.168.1.100"
+        every { docSnapshot.getString("dId") } returns "device123"
+
+        val status = sharedAccess.getCarStatus("thil", "181")
+
+        assertNotNull(status)
+        assertFalse(status!!.isOnline)
+    }
+
+    @Test
+    fun testFindDevicesByEmailAndTeamCode() {
+        val collection = mockk<CollectionReference>()
+        val query = mockk<Query>()
+        val querySnapshot = mockk<QuerySnapshot>()
+        val doc1 = mockk<QueryDocumentSnapshot>()
+        val doc2 = mockk<QueryDocumentSnapshot>()
+
+        every { db.collection("DeviceIds") } returns collection
+        every { collection.whereArrayContains("emailAddresses", "test@example.com") } returns query
+        every { query.get() } returns ApiFutures.immediateFuture(querySnapshot)
+        every { querySnapshot.documents } returns listOf(doc1, doc2)
+        every { doc1.getString("teamCode") } returns "team1"
+        every { doc1.id } returns "device1"
+        every { doc2.getString("teamCode") } returns "team2"
+        every { doc2.id } returns "device2"
+
+        val devices = sharedAccess.findDevicesByEmailAndTeamCode("test@example.com", "team1")
+
+        assertEquals(1, devices.size)
+        assertEquals("device1", devices[0])
+    }
+}


### PR DESCRIPTION
This allows code reuse (clumsy copy) that means the web frontend can query firestore directly avoiding the need to keep meringue running to power dormant logged in users on the website