### PR TITLE
catch events in the event system

### DIFF
--- a/src/main/kotlin/com/normtronix/meringue/event/Event.kt
+++ b/src/main/kotlin/com/normtronix/meringue/event/Event.kt
@@ -94,7 +94,11 @@ open class Event(val debounce: Boolean = false) {
             handlers?.forEach {
                 if (it.filter(event)) {
                     launch {
-                        it.handler.handleEvent(event)
+                        try {
+                            it.handler.handleEvent(event)
+                        } catch (e: Exception) {
+                            log.error("error handling event $event in ${it.handler.javaClass.simpleName}", e)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
log them.

This was a problem because the errors were in some cases propogating back to the grpc caller